### PR TITLE
Hard Defined Order for plugins

### DIFF
--- a/Noble_GTBS_core.js
+++ b/Noble_GTBS_core.js
@@ -12,7 +12,7 @@ Imported["Noble_GTBS_core"] = true;
  * @plugindesc [v1.0] 
  * @author LordValinar, SirLegna
  * @url 
- *
+ * @orderBefore Noble_GTBS_main
  *
  * @ --------------------------------------------------------------------------
  * Plugin Parameters

--- a/Noble_GTBS_main.js
+++ b/Noble_GTBS_main.js
@@ -12,6 +12,9 @@ Imported["Noble_GTBS_main"] = true;
  * @plugindesc [v1.0] 
  * @author LordValinar, SirLegna
  * @url 
+ * @base Noble_GTBS_core
+ * @orderAfter Noble_GTBS_core
+ *
  *
  *
  * @ --------------------------------------------------------------------------


### PR DESCRIPTION
Might be redundant for the base and orderAfter; but either way, it forces warnings if they aren't in the right order.